### PR TITLE
add additonal check when parsing uri path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,9 +36,17 @@ export function activate(context: vscode.ExtensionContext) {
 			const api = clangdExtension.exports.getApi(CLANGD_API_VERSION);
 			const client = api.languageClient;
 			if (client) {
+				// <<<<---- The main changes are here ---->>>>
+				let sourceUri: vscode.Uri;
+				if (argument.uri.startsWith('file:///')) {
+					sourceUri = vscode.Uri.parse(argument.uri);
+				} else {
+					// Assume argument.uri is an absolute system path
+					sourceUri = vscode.Uri.file(argument.uri);
+				}
 				await vscode.commands.executeCommand(
 					'editor.action.showReferences',
-					vscode.Uri.parse(argument.uri),
+					sourceUri, // Using the Transformed URI
 					client.protocol2CodeConverter.asPosition(argument.position),
 					argument.locations.map(client.protocol2CodeConverter.asLocation),
 				);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,6 @@ export function activate(context: vscode.ExtensionContext) {
 			const api = clangdExtension.exports.getApi(CLANGD_API_VERSION);
 			const client = api.languageClient;
 			if (client) {
-				// <<<<---- The main changes are here ---->>>>
 				let sourceUri: vscode.Uri;
 				if (argument.uri.startsWith('file:///')) {
 					sourceUri = vscode.Uri.parse(argument.uri);


### PR DESCRIPTION
On Windows, when clicking the codelens tab, VSCode will give a "Cannot resolve resource" error because the argument.uri parameter is a system path instead of a uri path.
(Assistance provided by Gemini)